### PR TITLE
Updated the README to use Yarn for Local Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,22 @@ This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern 
 
 [![Build Status](https://dev.azure.com/glasswall/Glasswall%20Cloud/_apis/build/status/Glasswall.Engineering.Site/filetrust.glasswall-engineering-site?branchName=master)](https://dev.azure.com/glasswall/Glasswall%20Cloud/_build/latest?definitionId=468&branchName=master)
 
-### Installation
-
+### Yarn
 ```
-$ npm install
+npm install -g yarn
+```
+
+This command will install the Yarn package manager. Yarn is used to build the project in the deployment pipeline.
+
+### Installation
+```
+yarn install
 ```
 
 ### Local Development
 
 ```
-$ npm run start
+yarn start
 ```
 
 This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
@@ -21,10 +27,11 @@ This command starts a local development server and open up a browser window. Mos
 ### Build
 
 ```
-$ npm run build
+yarn build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
+
 
 ### Deployment
 


### PR DESCRIPTION
# Description
We're using Yarn to build the site in the automated deployment, both for Azure Pipelines and GitHub Actions.

In order to make sure local builds will give the same output as the pipeline, please use Yarn as shown in the README.

Requested all contributors to review this PR so no one misses it.